### PR TITLE
Fix spelling errors in the 6.2 patch AUSU -> ASUS

### DIFF
--- a/qemu-6.2.0.patch
+++ b/qemu-6.2.0.patch
@@ -3,11 +3,11 @@ index 356ec4c..544b3bc 100644
 --- a/block/vhdx.c
 +++ b/block/vhdx.c
 @@ -2004,7 +2004,7 @@ static int coroutine_fn vhdx_co_create(BlockdevCreateOptions *opts,
- 
+
      /* The creator field is optional, but may be useful for
       * debugging / diagnostics */
 -    creator = g_utf8_to_utf16("QEMU v" QEMU_VERSION, -1, NULL,
-+    creator = g_utf8_to_utf16("AUSU v" QEMU_VERSION, -1, NULL,
++    creator = g_utf8_to_utf16("ASUS v" QEMU_VERSION, -1, NULL,
                                &creator_items, NULL);
      signature = cpu_to_le64(VHDX_FILE_SIGNATURE);
      ret = blk_pwrite(blk, VHDX_FILE_ID_OFFSET, &signature, sizeof(signature),
@@ -20,9 +20,9 @@ index 5dacc6c..6a366ec 100644
          memcpy(s->volume_label, label, label_length);
      } else {
 -        memcpy(s->volume_label, "QEMU VVFAT", 10);
-+        memcpy(s->volume_label, "AUSU VVFAT", 10);
++        memcpy(s->volume_label, "ASUS VVFAT", 10);
      }
- 
+
      if (floppy) {
 diff --git a/chardev/msmouse.c b/chardev/msmouse.c
 index eb9231d..99c4b98 100644
@@ -30,10 +30,10 @@ index eb9231d..99c4b98 100644
 +++ b/chardev/msmouse.c
 @@ -150,7 +150,7 @@ static void char_msmouse_finalize(Object *obj)
  }
- 
+
  static QemuInputHandler msmouse_handler = {
 -    .name  = "QEMU Microsoft Mouse",
-+    .name  = "AUSU Microsoft Mouse",
++    .name  = "ASUS Microsoft Mouse",
      .mask  = INPUT_EVENT_MASK_BTN | INPUT_EVENT_MASK_REL,
      .event = msmouse_input_event,
      .sync  = msmouse_input_sync,
@@ -43,10 +43,10 @@ index e8b292c..fcbfa77 100644
 +++ b/chardev/wctablet.c
 @@ -179,7 +179,7 @@ static void wctablet_input_sync(DeviceState *dev)
  }
- 
+
  static QemuInputHandler wctablet_handler = {
 -    .name  = "QEMU Wacom Pen Tablet",
-+    .name  = "AUSU Wacom Pen Tablet",
++    .name  = "ASUS Wacom Pen Tablet",
      .mask  = INPUT_EVENT_MASK_BTN | INPUT_EVENT_MASK_ABS,
      .event = wctablet_input_event,
      .sync  = wctablet_input_sync,
@@ -57,9 +57,9 @@ index 611360e..aa08dfd 100644
 @@ -1190,7 +1190,7 @@ main(int argc, char *argv[])
      QTAILQ_INIT(&g.reslist);
      QTAILQ_INIT(&g.fenceq);
- 
+
 -    context = g_option_context_new("QEMU vhost-user-gpu");
-+    context = g_option_context_new("AUSU vhost-user-gpu");
++    context = g_option_context_new("ASUS vhost-user-gpu");
      g_option_context_add_main_entries(context, entries, NULL);
      if (!g_option_context_parse(context, &argc, &argv, &error)) {
          g_printerr("Option parsing failed: %s\n", error->message);
@@ -68,20 +68,20 @@ index af3164c..fcbf0f4 100644
 --- a/hw/arm/nseries.c
 +++ b/hw/arm/nseries.c
 @@ -846,7 +846,7 @@ static void n800_setup_nolo_tags(void *sram_base)
- 
+
      memset(p, 0, 0x3000);
- 
+
 -    strcpy((void *) (p + 0), "QEMU N800");
-+    strcpy((void *) (p + 0), "AUSU N800");
- 
++    strcpy((void *) (p + 0), "ASUS N800");
+
      strcpy((void *) (p + 8), "F5");
- 
+
 @@ -1151,7 +1151,7 @@ static int n8x0_atag_setup(void *p, int model)
- 
+
      stw_p(w++, OMAP_TAG_LCD);			/* u16 tag */
      stw_p(w++, 36);				/* u16 len */
 -    strcpy((void *) w, "QEMU LCD panel");	/* char panel_name[16] */
-+    strcpy((void *) w, "AUSU LCD panel");	/* char panel_name[16] */
++    strcpy((void *) w, "ASUS LCD panel");	/* char panel_name[16] */
      w += 8;
      strcpy((void *) w, "blizzard");		/* char ctrl_name[16] */
      w += 8;
@@ -90,12 +90,12 @@ index af3164c..fcbf0f4 100644
      strcpy((void *) w, "hw-build");		/* char component[12] */
      w += 6;
 -    strcpy((void *) w, "QEMU ");
-+    strcpy((void *) w, "AUSU ");
++    strcpy((void *) w, "ASUS ");
      pstrcat((void *) w, 12, qemu_hw_version()); /* char version[12] */
      w += 6;
- 
+
 -    tag = (model == 810) ? "1.1.10-qemu" : "1.1.6-qemu";
-+    tag = (model == 810) ? "1.1.10-ausu" : "1.1.6-ausu";
++    tag = (model == 810) ? "1.1.10-asus" : "1.1.6-asus";
      stw_p(w++, OMAP_TAG_VERSION_STR);		/* u16 tag */
      stw_p(w++, 24);				/* u16 len */
      strcpy((void *) w, "nolo");			/* char component[12] */
@@ -105,10 +105,10 @@ index 358714b..d7566a0 100644
 +++ b/hw/arm/sbsa-ref.c
 @@ -837,7 +837,7 @@ static void sbsa_ref_class_init(ObjectClass *oc, void *data)
      MachineClass *mc = MACHINE_CLASS(oc);
- 
+
      mc->init = sbsa_ref_init;
 -    mc->desc = "QEMU 'SBSA Reference' ARM Virtual Machine";
-+    mc->desc = "AUSU 'SBSA Reference' ARM Virtual Machine";
++    mc->desc = "ASUS 'SBSA Reference' ARM Virtual Machine";
      mc->default_cpu_type = ARM_CPU_TYPE_NAME("cortex-a57");
      mc->max_cpus = 512;
      mc->pci_allow_0_address = true;
@@ -121,26 +121,26 @@ index 30da05d..39a102b 100644
      uint8_t *smbios_tables, *smbios_anchor;
      size_t smbios_tables_len, smbios_anchor_len;
 -    const char *product = "QEMU Virtual Machine";
-+    const char *product = "AUSU Real Machine";
- 
++    const char *product = "ASUS Real Machine";
+
      if (kvm_enabled()) {
 -        product = "KVM Virtual Machine";
-+        product = "AUSU Real Machine";
++        product = "ASUS Real Machine";
      }
- 
+
 -    smbios_set_defaults("QEMU", product,
-+    smbios_set_defaults("AUSU", product,
++    smbios_set_defaults("ASUS", product,
                          vmc->smbios_old_sys_ver ? "1.0" : mc->name, false,
                          true, SMBIOS_ENTRY_POINT_30);
- 
+
 diff --git a/hw/audio/hda-codec.c b/hw/audio/hda-codec.c
 index feb8f9e..13cc211 100644
 --- a/hw/audio/hda-codec.c
 +++ b/hw/audio/hda-codec.c
 @@ -117,7 +117,7 @@ static void hda_codec_parse_fmt(uint32_t format, struct audsettings *as)
- 
+
  /* some defines */
- 
+
 -#define QEMU_HDA_ID_VENDOR  0x1af4
 +#define QEMU_HDA_ID_VENDOR  0x8086
  #define QEMU_HDA_PCM_FORMATS (AC_SUPPCM_BITS_16 |       \
@@ -151,11 +151,11 @@ index 8755d8d..52c52b6 100644
 --- a/hw/char/escc.c
 +++ b/hw/char/escc.c
 @@ -959,7 +959,7 @@ static void escc_realize(DeviceState *dev, Error **errp)
- 
+
      if (s->chn[0].type == escc_mouse) {
          qemu_add_mouse_event_handler(sunmouse_event, &s->chn[0], 0,
 -                                     "QEMU Sun Mouse");
-+                                     "AUSU Sun Mouse");
++                                     "ASUS Sun Mouse");
      }
      if (s->chn[1].type == escc_kbd) {
          s->chn[1].hs = qemu_input_handler_register((DeviceState *)(&s->chn[1]),
@@ -168,7 +168,7 @@ index f2b874d..ae68c73 100644
      }
      if (!info->name) {
 -        info->name = "QEMU Monitor";
-+        info->name = "AUSU Monitor";
++        info->name = "ASUS Monitor";
      }
      if (!info->prefx) {
          info->prefx = 1024;
@@ -182,8 +182,8 @@ index b626199..634adfb 100644
          buf[7] = 0;    /* reserved */
 -        padstr8(buf + 8, 8, "QEMU");
 -        padstr8(buf + 16, 16, "QEMU DVD-ROM");
-+        padstr8(buf + 8, 8, "AUSU");
-+        padstr8(buf + 16, 16, "AUSU DVD-ROM");
++        padstr8(buf + 8, 8, "ASUS");
++        padstr8(buf + 16, 16, "ASUS DVD-ROM");
          padstr8(buf + 32, 4, s->version);
          idx = 36;
      }
@@ -196,15 +196,15 @@ index e28f8aa..e54418a 100644
          switch (kind) {
          case IDE_CD:
 -            strcpy(s->drive_model_str, "QEMU DVD-ROM");
-+            strcpy(s->drive_model_str, "AUSU DVD-ROM");
++            strcpy(s->drive_model_str, "ASUS DVD-ROM");
              break;
          case IDE_CFATA:
 -            strcpy(s->drive_model_str, "QEMU MICRODRIVE");
-+            strcpy(s->drive_model_str, "AUSU MICRODRIVE");
++            strcpy(s->drive_model_str, "ASUS MICRODRIVE");
              break;
          default:
 -            strcpy(s->drive_model_str, "QEMU HARDDISK");
-+            strcpy(s->drive_model_str, "AUSU HARDDISK");
++            strcpy(s->drive_model_str, "ASUS HARDDISK");
              break;
          }
      }
@@ -214,10 +214,10 @@ index a9088c9..b282809 100644
 +++ b/hw/input/adb-kbd.c
 @@ -356,7 +356,7 @@ static void adb_kbd_reset(DeviceState *dev)
  }
- 
+
  static QemuInputHandler adb_keyboard_handler = {
 -    .name  = "QEMU ADB Keyboard",
-+    .name  = "AUSU ADB Keyboard",
++    .name  = "ASUS ADB Keyboard",
      .mask  = INPUT_EVENT_MASK_KEY,
      .event = adb_keyboard_event,
  };
@@ -226,52 +226,52 @@ index e6b341f..7b9224e 100644
 --- a/hw/input/adb-mouse.c
 +++ b/hw/input/adb-mouse.c
 @@ -236,7 +236,7 @@ static void adb_mouse_realizefn(DeviceState *dev, Error **errp)
- 
+
      amc->parent_realize(dev, errp);
- 
+
 -    qemu_add_mouse_event_handler(adb_mouse_event, s, 0, "QEMU ADB Mouse");
-+    qemu_add_mouse_event_handler(adb_mouse_event, s, 0, "AUSU ADB Mouse");
++    qemu_add_mouse_event_handler(adb_mouse_event, s, 0, "ASUS ADB Mouse");
  }
- 
+
  static void adb_mouse_initfn(Object *obj)
 diff --git a/hw/input/ads7846.c b/hw/input/ads7846.c
 index 1d4e04a..654e743 100644
 --- a/hw/input/ads7846.c
 +++ b/hw/input/ads7846.c
 @@ -154,7 +154,7 @@ static void ads7846_realize(SSIPeripheral *d, Error **errp)
- 
+
      /* We want absolute coordinates */
      qemu_add_mouse_event_handler(ads7846_ts_event, s, 1,
 -                    "QEMU ADS7846-driven Touchscreen");
-+                    "AUSU ADS7846-driven Touchscreen");
- 
++                    "ASUS ADS7846-driven Touchscreen");
+
      ads7846_int_update(s);
- 
+
 diff --git a/hw/input/hid.c b/hw/input/hid.c
 index 8aab052..83fb83d 100644
 --- a/hw/input/hid.c
 +++ b/hw/input/hid.c
 @@ -509,20 +509,20 @@ void hid_free(HIDState *hs)
  }
- 
+
  static QemuInputHandler hid_keyboard_handler = {
 -    .name  = "QEMU HID Keyboard",
-+    .name  = "AUSU HID Keyboard",
++    .name  = "ASUS HID Keyboard",
      .mask  = INPUT_EVENT_MASK_KEY,
      .event = hid_keyboard_event,
  };
- 
+
  static QemuInputHandler hid_mouse_handler = {
 -    .name  = "QEMU HID Mouse",
-+    .name  = "AUSU HID Mouse",
++    .name  = "ASUS HID Mouse",
      .mask  = INPUT_EVENT_MASK_BTN | INPUT_EVENT_MASK_REL,
      .event = hid_pointer_event,
      .sync  = hid_pointer_sync,
  };
- 
+
  static QemuInputHandler hid_tablet_handler = {
 -    .name  = "QEMU HID Tablet",
-+    .name  = "AUSU HID Tablet",
++    .name  = "ASUS HID Tablet",
      .mask  = INPUT_EVENT_MASK_BTN | INPUT_EVENT_MASK_ABS,
      .event = hid_pointer_event,
      .sync  = hid_pointer_sync,
@@ -281,19 +281,19 @@ index 9376a8f..dff01c7 100644
 +++ b/hw/input/ps2.c
 @@ -1178,7 +1178,7 @@ static const VMStateDescription vmstate_ps2_mouse = {
  };
- 
+
  static QemuInputHandler ps2_keyboard_handler = {
 -    .name  = "QEMU PS/2 Keyboard",
-+    .name  = "AUSU PS/2 Keyboard",
++    .name  = "ASUS PS/2 Keyboard",
      .mask  = INPUT_EVENT_MASK_KEY,
      .event = ps2_keyboard_event,
  };
 @@ -1199,7 +1199,7 @@ void *ps2_kbd_init(void (*update_irq)(void *, int), void *update_arg)
  }
- 
+
  static QemuInputHandler ps2_mouse_handler = {
 -    .name  = "QEMU PS/2 Mouse",
-+    .name  = "AUSU PS/2 Mouse",
++    .name  = "ASUS PS/2 Mouse",
      .mask  = INPUT_EVENT_MASK_BTN | INPUT_EVENT_MASK_REL,
      .event = ps2_mouse_event,
      .sync  = ps2_mouse_sync,
@@ -303,11 +303,11 @@ index 55d61cc..23eb6e3 100644
 +++ b/hw/input/tsc2005.c
 @@ -511,7 +511,7 @@ void *tsc2005_init(qemu_irq pintdav)
      tsc2005_reset(s);
- 
+
      qemu_add_mouse_event_handler(tsc2005_touchscreen_event, s, 1,
 -                    "QEMU TSC2005-driven Touchscreen");
-+                    "AUSU TSC2005-driven Touchscreen");
- 
++                    "ASUS TSC2005-driven Touchscreen");
+
      qemu_register_reset((void *) tsc2005_reset, s);
      vmstate_register(NULL, 0, &vmstate_tsc2005, s);
 diff --git a/hw/input/tsc210x.c b/hw/input/tsc210x.c
@@ -316,39 +316,39 @@ index 182d372..67a22ed 100644
 +++ b/hw/input/tsc210x.c
 @@ -1101,7 +1101,7 @@ uWireSlave *tsc2102_init(qemu_irq pint)
      tsc210x_reset(s);
- 
+
      qemu_add_mouse_event_handler(tsc210x_touchscreen_event, s, 1,
 -                    "QEMU TSC2102-driven Touchscreen");
-+                    "AUSU TSC2102-driven Touchscreen");
- 
++                    "ASUS TSC2102-driven Touchscreen");
+
      AUD_register_card(s->name, &s->card);
- 
+
 @@ -1149,7 +1149,7 @@ uWireSlave *tsc2301_init(qemu_irq penirq, qemu_irq kbirq, qemu_irq dav)
      tsc210x_reset(s);
- 
+
      qemu_add_mouse_event_handler(tsc210x_touchscreen_event, s, 1,
 -                    "QEMU TSC2301-driven Touchscreen");
-+                    "AUSU TSC2301-driven Touchscreen");
- 
++                    "ASUS TSC2301-driven Touchscreen");
+
      AUD_register_card(s->name, &s->card);
- 
+
 diff --git a/hw/input/virtio-input-hid.c b/hw/input/virtio-input-hid.c
 index a7a244a..02c2f8c 100644
 --- a/hw/input/virtio-input-hid.c
 +++ b/hw/input/virtio-input-hid.c
 @@ -16,9 +16,9 @@
- 
+
  #include "standard-headers/linux/input.h"
- 
+
 -#define VIRTIO_ID_NAME_KEYBOARD "QEMU Virtio Keyboard"
 -#define VIRTIO_ID_NAME_MOUSE    "QEMU Virtio Mouse"
 -#define VIRTIO_ID_NAME_TABLET   "QEMU Virtio Tablet"
-+#define VIRTIO_ID_NAME_KEYBOARD "AUSU Keyboard"
-+#define VIRTIO_ID_NAME_MOUSE    "AUSU Mouse"
-+#define VIRTIO_ID_NAME_TABLET   "AUSU Tablet"
- 
++#define VIRTIO_ID_NAME_KEYBOARD "ASUS Keyboard"
++#define VIRTIO_ID_NAME_MOUSE    "ASUS Mouse"
++#define VIRTIO_ID_NAME_TABLET   "ASUS Tablet"
+
  /* ----------------------------------------------------------------- */
- 
+
 diff --git a/hw/m68k/virt.c b/hw/m68k/virt.c
 index 0efa4a4..f333ca9 100644
 --- a/hw/m68k/virt.c
@@ -358,7 +358,7 @@ index 0efa4a4..f333ca9 100644
  {
      MachineClass *mc = MACHINE_CLASS(oc);
 -    mc->desc = "QEMU M68K Virtual Machine";
-+    mc->desc = "AUSU M68K Virtual Machine";
++    mc->desc = "ASUS M68K Virtual Machine";
      mc->init = virt_init;
      mc->default_cpu_type = M68K_CPU_TYPE_NAME("m68040");
      mc->max_cpus = 1;
@@ -367,14 +367,14 @@ index 5f573c4..4f05bda 100644
 --- a/hw/nvme/ctrl.c
 +++ b/hw/nvme/ctrl.c
 @@ -6412,7 +6412,7 @@ static void nvme_init_ctrl(NvmeCtrl *n, PCIDevice *pci_dev)
- 
+
      id->vid = cpu_to_le16(pci_get_word(pci_conf + PCI_VENDOR_ID));
      id->ssvid = cpu_to_le16(pci_get_word(pci_conf + PCI_SUBSYSTEM_VENDOR_ID));
 -    strpadcpy((char *)id->mn, sizeof(id->mn), "QEMU NVMe Ctrl", ' ');
-+    strpadcpy((char *)id->mn, sizeof(id->mn), "AUSU NVMe Ctrl", ' ');
++    strpadcpy((char *)id->mn, sizeof(id->mn), "ASUS NVMe Ctrl", ' ');
      strpadcpy((char *)id->fr, sizeof(id->fr), "1.0", ' ');
      strpadcpy((char *)id->sn, sizeof(id->sn), n->params.serial, ' ');
- 
+
 diff --git a/hw/nvram/fw_cfg.c b/hw/nvram/fw_cfg.c
 index c06b30d..253d12c 100644
 --- a/hw/nvram/fw_cfg.c
@@ -382,10 +382,10 @@ index c06b30d..253d12c 100644
 @@ -56,7 +56,7 @@
  #define FW_CFG_DMA_CTL_SELECT  0x08
  #define FW_CFG_DMA_CTL_WRITE   0x10
- 
+
 -#define FW_CFG_DMA_SIGNATURE 0x51454d5520434647ULL /* "QEMU CFG" */
-+#define FW_CFG_DMA_SIGNATURE 0x4155535520434647ULL /* "AUSU CFG" */
- 
++#define FW_CFG_DMA_SIGNATURE 0x4155535520434647ULL /* "ASUS CFG" */
+
  struct FWCfgEntry {
      uint32_t len;
 diff --git a/hw/pci-host/gpex.c b/hw/pci-host/gpex.c
@@ -394,10 +394,10 @@ index a6752fa..370f6d1 100644
 +++ b/hw/pci-host/gpex.c
 @@ -207,7 +207,7 @@ static void gpex_root_class_init(ObjectClass *klass, void *data)
      DeviceClass *dc = DEVICE_CLASS(klass);
- 
+
      set_bit(DEVICE_CATEGORY_BRIDGE, dc->categories);
 -    dc->desc = "QEMU generic PCIe host bridge";
-+    dc->desc = "AUSU generic PCIe host bridge";
++    dc->desc = "ASUS generic PCIe host bridge";
      dc->vmsd = &vmstate_gpex_root;
      k->vendor_id = PCI_VENDOR_ID_REDHAT;
      k->device_id = PCI_DEVICE_ID_REDHAT_PCIE_HOST;
@@ -406,13 +406,13 @@ index fc911bb..b10ee76 100644
 --- a/hw/ppc/e500plat.c
 +++ b/hw/ppc/e500plat.c
 @@ -22,7 +22,7 @@
- 
+
  static void e500plat_fixup_devtree(void *fdt)
  {
 -    const char model[] = "QEMU ppce500";
-+    const char model[] = "AUSU ppce500";
++    const char model[] = "ASUS ppce500";
      const char compatible[] = "fsl,qemu-e500";
- 
+
      qemu_fdt_setprop(fdt, "/", "model", model, sizeof(model));
 diff --git a/hw/scsi/mptconfig.c b/hw/scsi/mptconfig.c
 index 19d01f3..1aea882 100644
@@ -425,16 +425,16 @@ index 19d01f3..1aea882 100644
 -                              "s16s8s16s16s16",
 -                              "QEMU MPT Fusion",
 +                              "s11s4s51s41s91",
-+                              "AUSU MPT Fusion",
++                              "ASUS MPT Fusion",
                                "2.5",
 -                              "QEMU MPT Fusion",
 -                              "QEMU",
 -                              "0000111122223333");
-+                              "AUSU MPT Fusion",
-+                              "AUSU",
++                              "ASUS MPT Fusion",
++                              "ASUS",
 +                              "1145141919810000");
  }
- 
+
  static
 diff --git a/hw/scsi/scsi-bus.c b/hw/scsi/scsi-bus.c
 index 77325d8..41b9f69 100644
@@ -446,8 +446,8 @@ index 77325d8..41b9f69 100644
          r->buf[7] = 0x10 | (r->req.bus->info->tcq ? 0x02 : 0); /* Sync, TCQ.  */
 -        memcpy(&r->buf[8], "QEMU    ", 8);
 -        memcpy(&r->buf[16], "QEMU TARGET     ", 16);
-+        memcpy(&r->buf[8], "AUSU    ", 8);
-+        memcpy(&r->buf[16], "AUSU TARGET     ", 16);
++        memcpy(&r->buf[8], "ASUS    ", 8);
++        memcpy(&r->buf[16], "ASUS TARGET     ", 16);
          pstrcpy((char *) &r->buf[32], 4, qemu_hw_version());
      }
      return true;
@@ -460,7 +460,7 @@ index d491417..3bc053e 100644
      s->qdev.type = TYPE_DISK;
      if (!s->product) {
 -        s->product = g_strdup("QEMU HARDDISK");
-+        s->product = g_strdup("AUSU HARDDISK");
++        s->product = g_strdup("ASUS HARDDISK");
      }
      scsi_realize(&s->qdev, errp);
  out:
@@ -469,7 +469,7 @@ index d491417..3bc053e 100644
      s->features |= 1 << SCSI_DISK_F_REMOVABLE;
      if (!s->product) {
 -        s->product = g_strdup("QEMU CD-ROM");
-+        s->product = g_strdup("AUSU CD-ROM");
++        s->product = g_strdup("ASUS CD-ROM");
      }
      scsi_realize(&s->qdev, errp);
      aio_context_release(ctx);
@@ -483,9 +483,9 @@ index a07a8e1..dc5df23 100644
      resp_data[7] = 0x10;   /* Sync transfers */
 -    memcpy(&resp_data[16], "QEMU EMPTY      ", 16);
 -    memcpy(&resp_data[8], "QEMU    ", 8);
-+    memcpy(&resp_data[16], "AUSU EMPTY      ", 16);
-+    memcpy(&resp_data[8], "AUSU    ", 8);
- 
++    memcpy(&resp_data[16], "ASUS EMPTY      ", 16);
++    memcpy(&resp_data[8], "ASUS    ", 8);
+
      req->writing = 0;
      vscsi_preprocess_desc(req);
 diff --git a/hw/usb/dev-audio.c b/hw/usb/dev-audio.c
@@ -494,12 +494,12 @@ index 8748c1b..5003345 100644
 +++ b/hw/usb/dev-audio.c
 @@ -73,8 +73,8 @@ enum usb_audio_strings {
  };
- 
+
  static const USBDescStrings usb_audio_stringtable = {
 -    [STRING_MANUFACTURER]       = "QEMU",
 -    [STRING_PRODUCT]            = "QEMU USB Audio",
-+    [STRING_MANUFACTURER]       = "AUSU",
-+    [STRING_PRODUCT]            = "AUSU USB Audio",
++    [STRING_MANUFACTURER]       = "ASUS",
++    [STRING_PRODUCT]            = "ASUS USB Audio",
      [STRING_SERIALNUMBER]       = "1",
      [STRING_CONFIG]             = "Audio Configuration",
      [STRING_USBAUDIO_CONTROL]   = "Audio Device",
@@ -508,7 +508,7 @@ index 8748c1b..5003345 100644
      device_class_set_props(dc, usb_audio_properties);
      set_bit(DEVICE_CATEGORY_SOUND, dc->categories);
 -    k->product_desc   = "QEMU USB Audio Interface";
-+    k->product_desc   = "AUSU USB Audio Interface";
++    k->product_desc   = "ASUS USB Audio Interface";
      k->realize        = usb_audio_realize;
      k->handle_reset   = usb_audio_handle_reset;
      k->handle_control = usb_audio_handle_control;
@@ -518,43 +518,43 @@ index 1c7ae97..9200101 100644
 +++ b/hw/usb/dev-hid.c
 @@ -63,10 +63,10 @@ enum {
  };
- 
+
  static const USBDescStrings desc_strings = {
 -    [STR_MANUFACTURER]     = "QEMU",
 -    [STR_PRODUCT_MOUSE]    = "QEMU USB Mouse",
 -    [STR_PRODUCT_TABLET]   = "QEMU USB Tablet",
 -    [STR_PRODUCT_KEYBOARD] = "QEMU USB Keyboard",
-+    [STR_MANUFACTURER]     = "AUSU",
-+    [STR_PRODUCT_MOUSE]    = "AUSU USB Mouse",
-+    [STR_PRODUCT_TABLET]   = "AUSU USB Tablet",
-+    [STR_PRODUCT_KEYBOARD] = "AUSU USB Keyboard",
++    [STR_MANUFACTURER]     = "ASUS",
++    [STR_PRODUCT_MOUSE]    = "ASUS USB Mouse",
++    [STR_PRODUCT_TABLET]   = "ASUS USB Tablet",
++    [STR_PRODUCT_KEYBOARD] = "ASUS USB Keyboard",
      [STR_SERIAL_COMPAT]    = "42",
      [STR_CONFIG_MOUSE]     = "HID Mouse",
      [STR_CONFIG_TABLET]    = "HID Tablet",
 @@ -806,7 +806,7 @@ static void usb_tablet_class_initfn(ObjectClass *klass, void *data)
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
      uc->realize        = usb_tablet_realize;
 -    uc->product_desc   = "QEMU USB Tablet";
-+    uc->product_desc   = "AUSU USB Tablet";
++    uc->product_desc   = "ASUS USB Tablet";
      dc->vmsd = &vmstate_usb_ptr;
      device_class_set_props(dc, usb_tablet_properties);
      set_bit(DEVICE_CATEGORY_INPUT, dc->categories);
 @@ -829,7 +829,7 @@ static void usb_mouse_class_initfn(ObjectClass *klass, void *data)
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
      uc->realize        = usb_mouse_realize;
 -    uc->product_desc   = "QEMU USB Mouse";
-+    uc->product_desc   = "AUSU USB Mouse";
++    uc->product_desc   = "ASUS USB Mouse";
      dc->vmsd = &vmstate_usb_ptr;
      device_class_set_props(dc, usb_mouse_properties);
      set_bit(DEVICE_CATEGORY_INPUT, dc->categories);
 @@ -853,7 +853,7 @@ static void usb_keyboard_class_initfn(ObjectClass *klass, void *data)
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
      uc->realize        = usb_keyboard_realize;
 -    uc->product_desc   = "QEMU USB Keyboard";
-+    uc->product_desc   = "AUSU USB Keyboard";
++    uc->product_desc   = "ASUS USB Keyboard";
      dc->vmsd = &vmstate_usb_kbd;
      device_class_set_props(dc, usb_keyboard_properties);
      set_bit(DEVICE_CATEGORY_INPUT, dc->categories);
@@ -564,23 +564,23 @@ index e35813d..6f79770 100644
 +++ b/hw/usb/dev-hub.c
 @@ -104,9 +104,9 @@ enum {
  };
- 
+
  static const USBDescStrings desc_strings = {
 -    [STR_MANUFACTURER] = "QEMU",
 -    [STR_PRODUCT]      = "QEMU USB Hub",
 -    [STR_SERIALNUMBER] = "314159",
-+    [STR_MANUFACTURER] = "AUSU",
-+    [STR_PRODUCT]      = "AUSU USB Hub",
++    [STR_MANUFACTURER] = "ASUS",
++    [STR_PRODUCT]      = "ASUS USB Hub",
 +    [STR_SERIALNUMBER] = "114514",
  };
- 
+
  static const USBDescIface desc_iface_hub = {
 @@ -676,7 +676,7 @@ static void usb_hub_class_initfn(ObjectClass *klass, void *data)
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
      uc->realize        = usb_hub_realize;
 -    uc->product_desc   = "QEMU USB Hub";
-+    uc->product_desc   = "AUSU USB Hub";
++    uc->product_desc   = "ASUS USB Hub";
      uc->usb_desc       = &desc_hub;
      uc->find_device    = usb_hub_find_device;
      uc->handle_reset   = usb_hub_handle_reset;
@@ -589,22 +589,22 @@ index c1d1694..3a30505 100644
 --- a/hw/usb/dev-mtp.c
 +++ b/hw/usb/dev-mtp.c
 @@ -248,8 +248,8 @@ OBJECT_DECLARE_SIMPLE_TYPE(MTPState, USB_MTP)
- 
+
  /* ----------------------------------------------------------------------- */
- 
+
 -#define MTP_MANUFACTURER  "QEMU"
 -#define MTP_PRODUCT       "QEMU filesharing"
-+#define MTP_MANUFACTURER  "AUSU"
-+#define MTP_PRODUCT       "AUSU filesharing"
++#define MTP_MANUFACTURER  "ASUS"
++#define MTP_PRODUCT       "ASUS filesharing"
  #define MTP_WRITE_BUF_SZ  (512 * KiB)
- 
+
  enum {
 @@ -2092,7 +2092,7 @@ static void usb_mtp_class_initfn(ObjectClass *klass, void *data)
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
      uc->realize        = usb_mtp_realize;
 -    uc->product_desc   = "QEMU USB MTP";
-+    uc->product_desc   = "AUSU USB MTP";
++    uc->product_desc   = "ASUS USB MTP";
      uc->usb_desc       = &desc;
      uc->cancel_packet  = usb_mtp_cancel_packet;
      uc->handle_attach  = usb_desc_attach;
@@ -614,7 +614,7 @@ index 6c49c16..3c84360 100644
 +++ b/hw/usb/dev-network.c
 @@ -97,15 +97,15 @@ enum usbstring_idx {
  #define ETH_FRAME_LEN			1514 /* Max. octets in frame sans FCS */
- 
+
  static const USBDescStrings usb_net_stringtable = {
 -    [STRING_MANUFACTURER]       = "QEMU",
 -    [STRING_PRODUCT]            = "RNDIS/QEMU USB Network Device",
@@ -625,33 +625,33 @@ index 6c49c16..3c84360 100644
 -    [STRING_CDC]                = "QEMU USB Net CDC",
 -    [STRING_SUBSET]             = "QEMU USB Net Subset",
 -    [STRING_RNDIS]              = "QEMU USB Net RNDIS",
-+    [STRING_MANUFACTURER]       = "AUSU",
-+    [STRING_PRODUCT]            = "RNDIS/AUSU USB Network Device",
++    [STRING_MANUFACTURER]       = "ASUS",
++    [STRING_PRODUCT]            = "RNDIS/ASUS USB Network Device",
 +    [STRING_ETHADDR]            = "400114514405",
-+    [STRING_DATA]               = "AUSU USB Net Data Interface",
-+    [STRING_CONTROL]            = "AUSU USB Net Control Interface",
-+    [STRING_RNDIS_CONTROL]      = "AUSU USB Net RNDIS Control Interface",
-+    [STRING_CDC]                = "AUSU USB Net CDC",
-+    [STRING_SUBSET]             = "AUSU USB Net Subset",
-+    [STRING_RNDIS]              = "AUSU USB Net RNDIS",
++    [STRING_DATA]               = "ASUS USB Net Data Interface",
++    [STRING_CONTROL]            = "ASUS USB Net Control Interface",
++    [STRING_RNDIS_CONTROL]      = "ASUS USB Net RNDIS Control Interface",
++    [STRING_CDC]                = "ASUS USB Net CDC",
++    [STRING_SUBSET]             = "ASUS USB Net Subset",
++    [STRING_RNDIS]              = "ASUS USB Net RNDIS",
      [STRING_SERIALNUMBER]       = "1",
  };
- 
+
 @@ -720,7 +720,7 @@ static int ndis_query(USBNetState *s, uint32_t oid,
- 
+
      /* mandatory */
      case OID_GEN_VENDOR_DESCRIPTION:
 -        pstrcpy((char *)outbuf, outlen, "QEMU USB RNDIS Net");
-+        pstrcpy((char *)outbuf, outlen, "AUSU USB RNDIS Net");
++        pstrcpy((char *)outbuf, outlen, "ASUS USB RNDIS Net");
          return strlen((char *)outbuf) + 1;
- 
+
      case OID_GEN_VENDOR_DRIVER_VERSION:
 @@ -1401,7 +1401,7 @@ static void usb_net_class_initfn(ObjectClass *klass, void *data)
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
      uc->realize        = usb_net_realize;
 -    uc->product_desc   = "QEMU USB Network Interface";
-+    uc->product_desc   = "AUSU USB Network Interface";
++    uc->product_desc   = "ASUS USB Network Interface";
      uc->usb_desc       = &desc_net;
      uc->handle_reset   = usb_net_handle_reset;
      uc->handle_control = usb_net_handle_control;
@@ -661,32 +661,32 @@ index 63047d7..4ef41c9 100644
 +++ b/hw/usb/dev-serial.c
 @@ -119,9 +119,9 @@ enum {
  };
- 
+
  static const USBDescStrings desc_strings = {
 -    [STR_MANUFACTURER]    = "QEMU",
 -    [STR_PRODUCT_SERIAL]  = "QEMU USB SERIAL",
 -    [STR_PRODUCT_BRAILLE] = "QEMU USB BAUM BRAILLE",
-+    [STR_MANUFACTURER]    = "AUSU",
-+    [STR_PRODUCT_SERIAL]  = "AUSU USB SERIAL",
-+    [STR_PRODUCT_BRAILLE] = "AUSU USB BAUM BRAILLE",
++    [STR_MANUFACTURER]    = "ASUS",
++    [STR_PRODUCT_SERIAL]  = "ASUS USB SERIAL",
++    [STR_PRODUCT_BRAILLE] = "ASUS USB BAUM BRAILLE",
      [STR_SERIALNUMBER]    = "1",
  };
- 
+
 @@ -666,7 +666,7 @@ static void usb_serial_class_initfn(ObjectClass *klass, void *data)
      DeviceClass *dc = DEVICE_CLASS(klass);
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
 -    uc->product_desc   = "QEMU USB Serial";
-+    uc->product_desc   = "AUSU USB Serial";
++    uc->product_desc   = "ASUS USB Serial";
      uc->usb_desc       = &desc_serial;
      device_class_set_props(dc, serial_properties);
  }
 @@ -687,7 +687,7 @@ static void usb_braille_class_initfn(ObjectClass *klass, void *data)
      DeviceClass *dc = DEVICE_CLASS(klass);
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
 -    uc->product_desc   = "QEMU USB Braille";
-+    uc->product_desc   = "AUSU USB Braille";
++    uc->product_desc   = "ASUS USB Braille";
      uc->usb_desc       = &desc_braille;
      device_class_set_props(dc, braille_properties);
  }
@@ -697,31 +697,31 @@ index 91ffd9f..36802d8 100644
 @@ -80,8 +80,8 @@ OBJECT_DECLARE_SIMPLE_TYPE(USBCCIDState, USB_CCID_DEV)
  #define CCID_CONTROL_GET_CLOCK_FREQUENCIES  0x2
  #define CCID_CONTROL_GET_DATA_RATES         0x3
- 
+
 -#define CCID_PRODUCT_DESCRIPTION        "QEMU USB CCID"
 -#define CCID_VENDOR_DESCRIPTION         "QEMU"
-+#define CCID_PRODUCT_DESCRIPTION        "AUSU USB CCID"
-+#define CCID_VENDOR_DESCRIPTION         "AUSU"
++#define CCID_PRODUCT_DESCRIPTION        "ASUS USB CCID"
++#define CCID_VENDOR_DESCRIPTION         "ASUS"
  #define CCID_INTERFACE_NAME             "CCID Interface"
  #define CCID_SERIAL_NUMBER_STRING       "1"
  /*
 @@ -417,8 +417,8 @@ enum {
  };
- 
+
  static const USBDescStrings desc_strings = {
 -    [STR_MANUFACTURER]  = "QEMU",
 -    [STR_PRODUCT]       = "QEMU USB CCID",
-+    [STR_MANUFACTURER]  = "AUSU",
-+    [STR_PRODUCT]       = "AUSU USB CCID",
++    [STR_MANUFACTURER]  = "ASUS",
++    [STR_PRODUCT]       = "ASUS USB CCID",
      [STR_SERIALNUMBER]  = "1",
      [STR_INTERFACE]     = "CCID Interface",
  };
 @@ -1444,7 +1444,7 @@ static void ccid_class_initfn(ObjectClass *klass, void *data)
      HotplugHandlerClass *hc = HOTPLUG_HANDLER_CLASS(klass);
- 
+
      uc->realize        = ccid_realize;
 -    uc->product_desc   = "QEMU USB CCID";
-+    uc->product_desc   = "AUSU USB CCID";
++    uc->product_desc   = "ASUS USB CCID";
      uc->usb_desc       = &desc_ccid;
      uc->handle_reset   = ccid_handle_reset;
      uc->handle_control = ccid_handle_control;
@@ -731,21 +731,21 @@ index dca62d5..b929a5f 100644
 +++ b/hw/usb/dev-storage.c
 @@ -47,8 +47,8 @@ enum {
  };
- 
+
  static const USBDescStrings desc_strings = {
 -    [STR_MANUFACTURER] = "QEMU",
 -    [STR_PRODUCT]      = "QEMU USB HARDDRIVE",
-+    [STR_MANUFACTURER] = "AUSU",
-+    [STR_PRODUCT]      = "AUSU USB HARDDRIVE",
++    [STR_MANUFACTURER] = "ASUS",
++    [STR_PRODUCT]      = "ASUS USB HARDDRIVE",
      [STR_SERIALNUMBER] = "1",
      [STR_CONFIG_FULL]  = "Full speed config (usb 1.1)",
      [STR_CONFIG_HIGH]  = "High speed config (usb 2.0)",
 @@ -561,7 +561,7 @@ static void usb_msd_class_initfn_common(ObjectClass *klass, void *data)
      DeviceClass *dc = DEVICE_CLASS(klass);
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
 -    uc->product_desc   = "QEMU USB MSD";
-+    uc->product_desc   = "AUSU USB MSD";
++    uc->product_desc   = "ASUS USB MSD";
      uc->usb_desc       = &desc;
      uc->cancel_packet  = usb_msd_cancel_io;
      uc->handle_attach  = usb_desc_attach;
@@ -754,29 +754,29 @@ index ed687bc..ea3614a 100644
 --- a/hw/usb/dev-wacom.c
 +++ b/hw/usb/dev-wacom.c
 @@ -172,7 +172,7 @@ static int usb_mouse_poll(USBWacomState *s, uint8_t *buf, int len)
- 
+
      if (!s->mouse_grabbed) {
          s->eh_entry = qemu_add_mouse_event_handler(usb_mouse_event, s, 0,
 -                        "QEMU PenPartner tablet");
-+                        "AUSU PenPartner tablet");
++                        "ASUS PenPartner tablet");
          qemu_activate_mouse_event_handler(s->eh_entry);
          s->mouse_grabbed = 1;
      }
 @@ -210,7 +210,7 @@ static int usb_wacom_poll(USBWacomState *s, uint8_t *buf, int len)
- 
+
      if (!s->mouse_grabbed) {
          s->eh_entry = qemu_add_mouse_event_handler(usb_wacom_event, s, 1,
 -                        "QEMU PenPartner tablet");
-+                        "AUSU PenPartner tablet");
++                        "ASUS PenPartner tablet");
          qemu_activate_mouse_event_handler(s->eh_entry);
          s->mouse_grabbed = 1;
      }
 @@ -355,7 +355,7 @@ static void usb_wacom_class_init(ObjectClass *klass, void *data)
      DeviceClass *dc = DEVICE_CLASS(klass);
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
 -    uc->product_desc   = "QEMU PenPartner Tablet";
-+    uc->product_desc   = "AUSU PenPartner Tablet";
++    uc->product_desc   = "ASUS PenPartner Tablet";
      uc->usb_desc       = &desc_wacom;
      uc->realize        = usb_wacom_realize;
      uc->handle_reset   = usb_wacom_handle_reset;
@@ -785,10 +785,10 @@ index ed687bc..ea3614a 100644
      uc->unrealize      = usb_wacom_unrealize;
      set_bit(DEVICE_CATEGORY_INPUT, dc->categories);
 -    dc->desc = "QEMU PenPartner Tablet";
-+    dc->desc = "AUSU PenPartner Tablet";
++    dc->desc = "ASUS PenPartner Tablet";
      dc->vmsd = &vmstate_usb_wacom;
  }
- 
+
 diff --git a/hw/usb/u2f-emulated.c b/hw/usb/u2f-emulated.c
 index 63cceaa..311cf29 100644
 --- a/hw/usb/u2f-emulated.c
@@ -798,10 +798,10 @@ index 63cceaa..311cf29 100644
      kc->unrealize = u2f_emulated_unrealize;
      kc->recv_from_guest = u2f_emulated_recv_from_guest;
 -    dc->desc = "QEMU U2F emulated key";
-+    dc->desc = "AUSU U2F emulated key";
++    dc->desc = "ASUS U2F emulated key";
      device_class_set_props(dc, u2f_emulated_properties);
  }
- 
+
 diff --git a/hw/usb/u2f-passthru.c b/hw/usb/u2f-passthru.c
 index fc93429..8ba2294 100644
 --- a/hw/usb/u2f-passthru.c
@@ -811,7 +811,7 @@ index fc93429..8ba2294 100644
      kc->unrealize = u2f_passthru_unrealize;
      kc->recv_from_guest = u2f_passthru_recv_from_guest;
 -    dc->desc = "QEMU U2F passthrough key";
-+    dc->desc = "AUSU U2F passthrough key";
++    dc->desc = "ASUS U2F passthrough key";
      dc->vmsd = &u2f_passthru_vmstate;
      device_class_set_props(dc, u2f_passthru_properties);
      set_bit(DEVICE_CATEGORY_MISC, dc->categories);
@@ -822,9 +822,9 @@ index 5600124..682a1f2 100644
 @@ -322,7 +322,7 @@ static void u2f_key_class_init(ObjectClass *klass, void *data)
      DeviceClass *dc = DEVICE_CLASS(klass);
      USBDeviceClass *uc = USB_DEVICE_CLASS(klass);
- 
+
 -    uc->product_desc   = "QEMU U2F USB key";
-+    uc->product_desc   = "AUSU U2F USB key";
++    uc->product_desc   = "ASUS U2F USB key";
      uc->usb_desc       = &desc_u2f_key;
      uc->handle_reset   = u2f_key_handle_reset;
      uc->handle_control = u2f_key_handle_control;
@@ -833,10 +833,10 @@ index 5600124..682a1f2 100644
      uc->realize        = u2f_key_realize;
      uc->unrealize      = u2f_key_unrealize;
 -    dc->desc           = "QEMU U2F key";
-+    dc->desc           = "AUSU U2F key";
++    dc->desc           = "ASUS U2F key";
      dc->vmsd           = &vmstate_u2f_key;
  }
- 
+
 diff --git a/include/hw/acpi/aml-build.h b/include/hw/acpi/aml-build.h
 index 8346003..e91faac 100644
 --- a/include/hw/acpi/aml-build.h
@@ -844,12 +844,12 @@ index 8346003..e91faac 100644
 @@ -4,8 +4,8 @@
  #include "hw/acpi/acpi-defs.h"
  #include "hw/acpi/bios-linker-loader.h"
- 
+
 -#define ACPI_BUILD_APPNAME6 "BOCHS "
 -#define ACPI_BUILD_APPNAME8 "BXPC    "
 +#define ACPI_BUILD_APPNAME6 "INTEL "
 +#define ACPI_BUILD_APPNAME8 "PC8086  "
- 
+
  #define ACPI_BUILD_TABLE_FILE "etc/acpi/tables"
  #define ACPI_BUILD_RSDP_FILE "etc/acpi/rsdp"
 diff --git a/include/hw/i386/pc.h b/include/hw/i386/pc.h
@@ -863,10 +863,10 @@ index 9ab39e4..740d2b1 100644
 -    { "qemu32-" TYPE_X86_CPU, "model-id", "QEMU Virtual CPU version " v, },\
 -    { "qemu64-" TYPE_X86_CPU, "model-id", "QEMU Virtual CPU version " v, },\
 -    { "athlon-" TYPE_X86_CPU, "model-id", "QEMU Virtual CPU version " v, },
-+    { "ausu32-" TYPE_X86_CPU, "model-id", "AUSU Real CPU version " v, },\
-+    { "ausu64-" TYPE_X86_CPU, "model-id", "AUSU Real CPU version " v, },\
-+    { "athlon-" TYPE_X86_CPU, "model-id", "AUSU Real CPU version " v, },
- 
++    { "asus32-" TYPE_X86_CPU, "model-id", "ASUS Real CPU version " v, },\
++    { "asus64-" TYPE_X86_CPU, "model-id", "ASUS Real CPU version " v, },\
++    { "athlon-" TYPE_X86_CPU, "model-id", "ASUS Real CPU version " v, },
+
  #define DEFINE_PC_MACHINE(suffix, namestr, initfn, optsfn) \
      static void pc_machine_##suffix##_class_init(ObjectClass *oc, void *data) \
 diff --git a/include/standard-headers/linux/qemu_fw_cfg.h b/include/standard-headers/linux/qemu_fw_cfg.h
@@ -876,10 +876,10 @@ index cb93f66..adb6b82 100644
 @@ -71,7 +71,7 @@ struct fw_cfg_file {
  #define FW_CFG_DMA_CTL_SELECT	0x08
  #define FW_CFG_DMA_CTL_WRITE	0x10
- 
+
 -#define FW_CFG_DMA_SIGNATURE    0x51454d5520434647ULL /* "QEMU CFG" */
 +#define FW_CFG_DMA_SIGNATURE    0x4155535520434647ULL /* "QEMU CFG" */
- 
+
  /* Control as first field allows for different structures selected by this
   * field, which might be useful in the future
 diff --git a/migration/migration.c b/migration/migration.c
@@ -887,20 +887,20 @@ index abaf6f9..1936312 100644
 --- a/migration/migration.c
 +++ b/migration/migration.c
 @@ -1173,7 +1173,7 @@ static bool migrate_caps_check(bool *cap_list,
- 
+
  #ifndef CONFIG_LIVE_BLOCK_MIGRATION
      if (cap_list[MIGRATION_CAPABILITY_BLOCK]) {
 -        error_setg(errp, "QEMU compiled without old-style (blk/-b, inc/-i) "
-+        error_setg(errp, "AUSU compiled without old-style (blk/-b, inc/-i) "
++        error_setg(errp, "ASUS compiled without old-style (blk/-b, inc/-i) "
                     "block migration");
          error_append_hint(errp, "Use drive_mirror+NBD instead.\n");
          return false;
 @@ -1182,7 +1182,7 @@ static bool migrate_caps_check(bool *cap_list,
- 
+
  #ifndef CONFIG_REPLICATION
      if (cap_list[MIGRATION_CAPABILITY_X_COLO]) {
 -        error_setg(errp, "QEMU compiled without replication module"
-+        error_setg(errp, "AUSU compiled without replication module"
++        error_setg(errp, "ASUS compiled without replication module"
                     " can't enable COLO");
          error_append_hint(errp, "Please enable replication before COLO.\n");
          return false;
@@ -913,7 +913,7 @@ index f5d3bbe..8c4bd8e 100644
          [RDMA_CONTROL_ERROR] = "ERROR",
          [RDMA_CONTROL_READY] = "READY",
 -        [RDMA_CONTROL_QEMU_FILE] = "QEMU FILE",
-+        [RDMA_CONTROL_QEMU_FILE] = "AUSU FILE",
++        [RDMA_CONTROL_QEMU_FILE] = "ASUS FILE",
          [RDMA_CONTROL_RAM_BLOCKS_REQUEST] = "RAM BLOCKS REQUEST",
          [RDMA_CONTROL_RAM_BLOCKS_RESULT] = "RAM BLOCKS RESULT",
          [RDMA_CONTROL_COMPRESS] = "COMPRESS",
@@ -924,10 +924,10 @@ index 8d74c0d..0218186 100644
 @@ -43,7 +43,7 @@
  #define FW_CFG_DMA_CTL_SELECT  0x08
  #define FW_CFG_DMA_CTL_WRITE   0x10
- 
+
 -#define FW_CFG_DMA_SIGNATURE 0x51454d5520434647ULL /* "QEMU CFG" */
-+#define FW_CFG_DMA_SIGNATURE 0x4155535520434647ULL /* "AUSU CFG" */
- 
++#define FW_CFG_DMA_SIGNATURE 0x4155535520434647ULL /* "ASUS CFG" */
+
  #define BIOS_CFG_DMA_ADDR_HIGH  0x514
  #define BIOS_CFG_DMA_ADDR_LOW   0x518
 diff --git a/pc-bios/s390-ccw/virtio-scsi.h b/pc-bios/s390-ccw/virtio-scsi.h
@@ -937,10 +937,10 @@ index 4b14c2c..02e69c7 100644
 @@ -25,7 +25,7 @@
  #define VIRTIO_SCSI_S_OK                     0x00
  #define VIRTIO_SCSI_S_BAD_TARGET             0x03
- 
+
 -#define QEMU_CDROM_SIGNATURE "QEMU CD-ROM     "
-+#define QEMU_CDROM_SIGNATURE "AUSU CD-ROM     "
- 
++#define QEMU_CDROM_SIGNATURE "ASUS CD-ROM     "
+
  enum virtio_scsi_vq_id {
      VR_CONTROL  = 0,
 diff --git a/target/i386/kvm/kvm.c b/target/i386/kvm/kvm.c
@@ -949,7 +949,7 @@ index 5a698bd..3e1190b 100644
 +++ b/target/i386/kvm/kvm.c
 @@ -1639,7 +1639,7 @@ int kvm_arch_init_vcpu(CPUState *cs)
      }
- 
+
      if (cpu->expose_kvm) {
 -        memcpy(signature, "KVMKVMKVM\0\0\0", 12);
 +        memcpy(signature, "GenuineIntel", 12);
@@ -963,9 +963,9 @@ index aab9c47..7d43742 100644
 @@ -322,18 +322,18 @@ uint32_t HELPER(stsi)(CPUS390XState *env, uint64_t a0, uint64_t r0, uint64_t r1)
              /* Basic Machine Configuration */
              char type[5] = {};
- 
+
 -            ebcdic_put(sysib.sysib_111.manuf, "QEMU            ", 16);
-+            ebcdic_put(sysib.sysib_111.manuf, "AUSU            ", 16);
++            ebcdic_put(sysib.sysib_111.manuf, "ASUS            ", 16);
              /* same as machine type number in STORE CPU ID, but in EBCDIC */
              snprintf(type, ARRAY_SIZE(type), "%X", cpu->model->def->type);
              ebcdic_put(sysib.sysib_111.type, type, 4);
@@ -973,15 +973,15 @@ index aab9c47..7d43742 100644
 -            ebcdic_put(sysib.sysib_111.model, "QEMU            ", 16);
 -            ebcdic_put(sysib.sysib_111.sequence, "QEMU            ", 16);
 -            ebcdic_put(sysib.sysib_111.plant, "QEMU", 4);
-+            ebcdic_put(sysib.sysib_111.model, "AUSU            ", 16);
-+            ebcdic_put(sysib.sysib_111.sequence, "AUSU            ", 16);
-+            ebcdic_put(sysib.sysib_111.plant, "AUSU", 4);
++            ebcdic_put(sysib.sysib_111.model, "ASUS            ", 16);
++            ebcdic_put(sysib.sysib_111.sequence, "ASUS            ", 16);
++            ebcdic_put(sysib.sysib_111.plant, "ASUS", 4);
          } else if ((sel1 == 2) && (sel2 == 1)) {
              /* Basic Machine CPU */
 -            ebcdic_put(sysib.sysib_121.sequence, "QEMUQEMUQEMUQEMU", 16);
 -            ebcdic_put(sysib.sysib_121.plant, "QEMU", 4);
-+            ebcdic_put(sysib.sysib_121.sequence, "AUSUAUSUAUSUAUSU", 16);
-+            ebcdic_put(sysib.sysib_121.plant, "AUSU", 4);
++            ebcdic_put(sysib.sysib_121.sequence, "ASUSASUSASUSASUS", 16);
++            ebcdic_put(sysib.sysib_121.plant, "ASUS", 4);
              sysib.sysib_121.cpu_addr = cpu_to_be16(env->core_id);
          } else if ((sel1 == 2) && (sel2 == 2)) {
              /* Basic Machine CPUs */
@@ -991,8 +991,8 @@ index aab9c47..7d43742 100644
              /* LPAR CPU */
 -            ebcdic_put(sysib.sysib_221.sequence, "QEMUQEMUQEMUQEMU", 16);
 -            ebcdic_put(sysib.sysib_221.plant, "QEMU", 4);
-+            ebcdic_put(sysib.sysib_221.sequence, "AUSUAUSUAUSUAUSU", 16);
-+            ebcdic_put(sysib.sysib_221.plant, "AUSU", 4);
++            ebcdic_put(sysib.sysib_221.sequence, "ASUSASUSASUSASUS", 16);
++            ebcdic_put(sysib.sysib_221.plant, "ASUS", 4);
              sysib.sysib_221.cpu_addr = cpu_to_be16(env->core_id);
          } else if ((sel1 == 2) && (sel2 == 2)) {
              /* LPAR CPUs */
@@ -1001,20 +1001,20 @@ index aab9c47..7d43742 100644
              sysib.sysib_322.vm[0].caf = cpu_to_be32(1000);
              /* Linux kernel uses this to distinguish us from z/VM */
 -            ebcdic_put(sysib.sysib_322.vm[0].cpi, "KVM/Linux       ", 16);
-+            ebcdic_put(sysib.sysib_322.vm[0].cpi, "AUSU/Linux       ", 16);
++            ebcdic_put(sysib.sysib_322.vm[0].cpi, "ASUS/Linux       ", 16);
              sysib.sysib_322.vm[0].ext_name_encoding = 2; /* UTF-8 */
- 
+
              /* If our VM has a name, use the real name */
 diff --git a/ui/spice-core.c b/ui/spice-core.c
 index 31974b8..0d5e935 100644
 --- a/ui/spice-core.c
 +++ b/ui/spice-core.c
 @@ -807,7 +807,7 @@ static void qemu_spice_init(void)
- 
+
      qemu_opt_foreach(opts, add_channel, &tls_port, &error_fatal);
- 
+
 -    spice_server_set_name(spice_server, qemu_name ?: "QEMU " QEMU_VERSION);
-+    spice_server_set_name(spice_server, qemu_name ?: "AUSU " QEMU_VERSION);
++    spice_server_set_name(spice_server, qemu_name ?: "ASUS " QEMU_VERSION);
      spice_server_set_uuid(spice_server, (unsigned char *)&qemu_uuid);
- 
+
      seamless_migration = qemu_opt_get_bool(opts, "seamless-migration", 0);


### PR DESCRIPTION
Replace `AUSU` and `ausu` with `ASUS` and `asus`